### PR TITLE
Fixing jvm property issue in ub script

### DIFF
--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -22,6 +22,7 @@ import (
 	pt "path"
 
 	"crypto/tls"
+
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
 	"golang.org/x/sys/unix"
@@ -480,15 +481,21 @@ func getEnvWithFallbacks(defaultValue string, envVars ...string) string {
 	return defaultValue
 }
 
-func invokeJavaCommand(className string, jvmOpts string, args []string) bool {
-	classPath := getEnvWithFallbacks("/usr/share/java/cp-base-java/*", "UB_CLASSPATH", "CUB_CLASSPATH")
-
+func buildJavaCommandArgs(jvmOpts string, classPath string, className string, args []string) []string {
 	opts := []string{}
 	if jvmOpts != "" {
 		opts = append(opts, strings.Fields(jvmOpts)...)
 	}
 	opts = append(opts, "-cp", classPath, className)
-	cmd := exec.Command("java", append(opts[:], args...)...)
+	opts = append(opts, args...)
+	return opts
+}
+
+func invokeJavaCommand(className string, jvmOpts string, args []string) bool {
+	classPath := getEnvWithFallbacks("/usr/share/java/cp-base-java/*", "UB_CLASSPATH", "CUB_CLASSPATH")
+	cmdArgs := buildJavaCommandArgs(jvmOpts, classPath, className, args)
+
+	cmd := exec.Command("java", cmdArgs...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -485,7 +485,7 @@ func invokeJavaCommand(className string, jvmOpts string, args []string) bool {
 
 	opts := []string{}
 	if jvmOpts != "" {
-		opts = append(opts, jvmOpts)
+		opts = append(opts, strings.Fields(jvmOpts)...)
 	}
 	opts = append(opts, "-cp", classPath, className)
 	cmd := exec.Command("java", append(opts[:], args...)...)

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 )
@@ -1582,6 +1583,43 @@ func Test_runConnectReadyCmd(t *testing.T) {
 			err := runConnectReadyCmd(tt.args)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("runConnectReadyCmd() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_invokeJavaCommand_JVMOptsSplitting(t *testing.T) {
+	tests := []struct {
+		name     string
+		jvmOpts  string
+		wantArgs int
+	}{
+		{
+			name:     "empty string",
+			jvmOpts:  "",
+			wantArgs: 0,
+		},
+		{
+			name:     "single option",
+			jvmOpts:  "-Xmx512M",
+			wantArgs: 1,
+		},
+		{
+			name:     "multiple options with authentication URL",
+			jvmOpts:  "-Xmx512M -Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=https://login.microsoftonline.com/*",
+			wantArgs: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := []string{}
+			if tt.jvmOpts != "" {
+				opts = append(opts, strings.Fields(tt.jvmOpts)...)
+			}
+
+			if len(opts) != tt.wantArgs {
+				t.Errorf("got %d args, want %d. Input: %q, Args: %v", len(opts), tt.wantArgs, tt.jvmOpts, opts)
 			}
 		})
 	}


### PR DESCRIPTION
Below the bug report
```
Caused by: org.apache.kafka.common.config.ConfigException: The class org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever defined in the sasl.oauthbearer.jwt.retriever.class configuration encountered an error on configure(): Invalid value <tokenEndpoint> for configuration sasl.oauthbearer.token.endpoint.url: The URL cannot be accessed due to restrictions. Update the system property 'org.apache.kafka.sasl.oauthbearer.allowed.urls' to allow the URL to be accessed.
```
More details here: https://confluent.slack.com/archives/C055SK92MD1/p1763396218469499

**Root cause:** Kafka 8.x requires OAuth token URLs to be explicitly allowed via JVM system property, but the old code couldn't pass it correctly.

## Visual Comparison

### OLD (master) - Broken 
```
KAFKA_OPTS="-Xmx512M -Dorg.apache...allowed.urls=https://..."

In code:
  opts = append(opts, jvmOpts)

Java receives:
  arg[0]: "-Xmx512M -Dorg.apache...allowed.urls=https://..."
          └────────────── ONE MALFORMED ARGUMENT ──────────────┘

Result: JVM can't parse → OAuth property not set → Connection fails
```

### NEW (fix-bug-jvm) - Fixed 
```
KAFKA_OPTS="-Xmx512M -Dorg.apache...allowed.urls=https://..."

In code:
  opts = append(opts, strings.Fields(jvmOpts)...)

Java receives:
  arg[0]: "-Xmx512M"
  arg[1]: "-Dorg.apache...allowed.urls=https://..."
          └────────── TWO SEPARATE VALID ARGUMENTS ──────────┘