### PR TITLE
CPBR-3846: ub - resolve classpath via UB_DEFAULT_CLASSPATH so CUB_CLASSPATH is honored on micro

### DIFF
--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -481,6 +481,27 @@ func getEnvWithFallbacks(defaultValue string, envVars ...string) string {
 	return defaultValue
 }
 
+// resolveClassPath determines the Java classpath used for ub-invoked commands.
+//
+// Precedence (highest first):
+//  1. UB_CLASSPATH       - explicit runtime override (canonical)
+//  2. CUB_CLASSPATH      - explicit runtime override (legacy; kept for
+//     backward compatibility)
+//  3. UB_DEFAULT_CLASSPATH - per-image default, set by the base-image Dockerfile
+//     (e.g. cp-base-java-micro sets /usr/share/java/cp-base-java-micro/*)
+//  4. built-in default
+//
+// The per-image default lives in UB_DEFAULT_CLASSPATH, *below* the user
+// override vars, rather than in UB_CLASSPATH. Baking it into UB_CLASSPATH would
+// make that var always non-empty at runtime and short-circuit the fallback,
+// silently ignoring a user-set CUB_CLASSPATH on images that ship a non-standard
+// default classpath (the cp-base-java-micro regression). Keeping it lowest
+// preserves both the image default and CUB_CLASSPATH back-compat.
+func resolveClassPath() string {
+	defaultClassPath := getEnvWithFallbacks("/usr/share/java/cp-base-java/*", "UB_DEFAULT_CLASSPATH")
+	return getEnvWithFallbacks(defaultClassPath, "UB_CLASSPATH", "CUB_CLASSPATH")
+}
+
 func buildJavaCommandArgs(jvmOpts string, classPath string, className string, args []string) []string {
 	opts := []string{}
 	if jvmOpts != "" {
@@ -492,7 +513,7 @@ func buildJavaCommandArgs(jvmOpts string, classPath string, className string, ar
 }
 
 func invokeJavaCommand(className string, jvmOpts string, args []string) bool {
-	classPath := getEnvWithFallbacks("/usr/share/java/cp-base-java/*", "UB_CLASSPATH", "CUB_CLASSPATH")
+	classPath := resolveClassPath()
 	cmdArgs := buildJavaCommandArgs(jvmOpts, classPath, className, args)
 
 	cmd := exec.Command("java", cmdArgs...)

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -1258,16 +1258,8 @@ func Test_resolveClassPath(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, key := range classPathVars {
-				os.Unsetenv(key)
+				t.Setenv(key, tt.envSetup[key])
 			}
-			for key, value := range tt.envSetup {
-				os.Setenv(key, value)
-			}
-			defer func() {
-				for _, key := range classPathVars {
-					os.Unsetenv(key)
-				}
-			}()
 
 			if result := resolveClassPath(); result != tt.expected {
 				t.Errorf("resolveClassPath() = %q, expected %q", result, tt.expected)

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -1212,6 +1212,70 @@ func Test_getEnvWithFallbacks(t *testing.T) {
 	}
 }
 
+func Test_resolveClassPath(t *testing.T) {
+	const (
+		base  = "/usr/share/java/cp-base-java/*"
+		micro = "/usr/share/java/cp-base-java-micro/*"
+	)
+	tests := []struct {
+		name     string
+		envSetup map[string]string
+		expected string
+	}{
+		{
+			name:     "no overrides falls back to built-in default",
+			envSetup: map[string]string{},
+			expected: base,
+		},
+		{
+			name:     "image default via UB_DEFAULT_CLASSPATH (e.g. micro)",
+			envSetup: map[string]string{"UB_DEFAULT_CLASSPATH": micro},
+			expected: micro,
+		},
+		{
+			name:     "user CUB_CLASSPATH wins over image default (legacy back-compat)",
+			envSetup: map[string]string{"UB_DEFAULT_CLASSPATH": micro, "CUB_CLASSPATH": "/my/jars/*"},
+			expected: "/my/jars/*",
+		},
+		{
+			name:     "explicit UB_CLASSPATH wins over image default",
+			envSetup: map[string]string{"UB_DEFAULT_CLASSPATH": micro, "UB_CLASSPATH": "/my/jars/*"},
+			expected: "/my/jars/*",
+		},
+		{
+			name:     "UB_CLASSPATH takes precedence over CUB_CLASSPATH",
+			envSetup: map[string]string{"UB_CLASSPATH": "/a/*", "CUB_CLASSPATH": "/b/*"},
+			expected: "/a/*",
+		},
+		{
+			name:     "CUB_CLASSPATH honored when no UB_CLASSPATH/default set",
+			envSetup: map[string]string{"CUB_CLASSPATH": "/legacy/*"},
+			expected: "/legacy/*",
+		},
+	}
+
+	classPathVars := []string{"UB_CLASSPATH", "CUB_CLASSPATH", "UB_DEFAULT_CLASSPATH"}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range classPathVars {
+				os.Unsetenv(key)
+			}
+			for key, value := range tt.envSetup {
+				os.Setenv(key, value)
+			}
+			defer func() {
+				for _, key := range classPathVars {
+					os.Unsetenv(key)
+				}
+			}()
+
+			if result := resolveClassPath(); result != tt.expected {
+				t.Errorf("resolveClassPath() = %q, expected %q", result, tt.expected)
+			}
+		})
+	}
+}
+
 func Test_runComponentReadyCmd(t *testing.T) {
 	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {


### PR DESCRIPTION
## Problem

`ub` resolves its Java classpath with `getEnvWithFallbacks("/usr/share/java/cp-base-java/*", "UB_CLASSPATH", "CUB_CLASSPATH")` — first non-empty wins, in that order. The `CUB_CLASSPATH` fallback exists for backward compatibility (projects that set `CUB_CLASSPATH` before the cub/dub → ub migration).

`cp-base-java-micro` installs its jars to `/usr/share/java/cp-base-java-micro/*`, and to point `ub` there its Dockerfile bakes in `ENV UB_CLASSPATH=/usr/share/java/cp-base-java-micro/*`. That makes `UB_CLASSPATH` **always non-empty at runtime**, so the fallback short-circuits on it and **`CUB_CLASSPATH` is never consulted** on micro images — a backward-compat regression for anyone setting `CUB_CLASSPATH`. Non-micro `cp-base-java` is unaffected (it sets neither var, so the in-code default applies and `CUB_CLASSPATH` still works).

## Fix

Move the per-image default *out* of the override slot into a new, lowest-priority `UB_DEFAULT_CLASSPATH`. Resolution becomes:

| Priority | Source |
|---|---|
| 1 | `UB_CLASSPATH` (runtime override, canonical) |
| 2 | `CUB_CLASSPATH` (runtime override, legacy back-compat) |
| 3 | `UB_DEFAULT_CLASSPATH` (per-image default, set by the base-image Dockerfile) |
| 4 | built-in `/usr/share/java/cp-base-java/*` |

Base images set `UB_DEFAULT_CLASSPATH` instead of `UB_CLASSPATH`, so the image default still applies when nobody overrides, while a user-set `CUB_CLASSPATH`/`UB_CLASSPATH` wins again.

**Purely additive — zero behavior change when `UB_DEFAULT_CLASSPATH` is unset**, so existing images and branches that don't opt in behave exactly as before.

## Tests

Added `Test_resolveClassPath` covering the full precedence matrix (no overrides → built-in default; image default only; `CUB_CLASSPATH` beats image default; `UB_CLASSPATH` beats image default; `UB_CLASSPATH` beats `CUB_CLASSPATH`; legacy `CUB_CLASSPATH`-only). `go test ./cmd/ub/` passes.

## Rollout (coordination required)

This binary is pinned by `common-docker` via `git-repo.cp-docker-utils.tag` and built with `go install …/cmd/ub@<tag>`. Sequencing to avoid regressing micro to the original `ClassNotFoundException`:

1. Merge this PR and cut a new `cp-docker-utils` tag.
2. In `common-docker` (master + 8.3.x), in the **same PR**: bump `git-repo.cp-docker-utils.tag` to the new tag **and** change `base-java-micro/Dockerfile.ubi9` from `ENV UB_CLASSPATH=…` to `ENV UB_DEFAULT_CLASSPATH=…`.

Tracking: CPBR-3281 (ubi9-micro migration).