### PR TITLE
Fix ub listeners to match legacy cub behavior (INC-11376)

### DIFF
--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -89,9 +89,6 @@ var (
 
 	re = regexp.MustCompile("[^_]_[^_]")
 
-	// listenerHostRe matches the host portion of a listener entry, i.e. the text
-	// between "://" and the following ":". This mirrors the legacy `cub` regex
-	// (`://(.*?):`) used to derive `listeners` from `advertised.listeners`.
 	listenerHostRe = regexp.MustCompile("://(.*?):")
 
 	ensureCmd = &cobra.Command{

--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -89,6 +89,11 @@ var (
 
 	re = regexp.MustCompile("[^_]_[^_]")
 
+	// listenerHostRe matches the host portion of a listener entry, i.e. the text
+	// between "://" and the following ":". This mirrors the legacy `cub` regex
+	// (`://(.*?):`) used to derive `listeners` from `advertised.listeners`.
+	listenerHostRe = regexp.MustCompile("://(.*?):")
+
 	ensureCmd = &cobra.Command{
 		Use:   "ensure <environment-variable>",
 		Short: "checks if environment variable is set or not",
@@ -853,43 +858,22 @@ func parseLog4jLoggers(loggersStr string, defaultLoggers ...map[string]string) m
 	return result
 }
 
+// runListenersCmd derives the `listeners` value from `advertised.listeners` by
+// replacing the host of every listener entry with 0.0.0.0, so the broker binds
+// on all interfaces while still advertising its real address. The listener name
+// (protocol prefix) and port are preserved.
+//
+// This intentionally mirrors the legacy `cub` behavior exactly: a single regex
+// substitution of `://(.*?):` -> `://0.0.0.0:` over the whole input string. As a
+// result, listener names/prefixes are kept (e.g. PLAINTEXT://foo:9092 ->
+// PLAINTEXT://0.0.0.0:9092), entries without a protocol prefix pass through
+// unchanged, and surrounding whitespace/trailing separators are left intact.
 func runListenersCmd(args []string) (string, error) {
 	if len(args) != 1 {
 		return "", fmt.Errorf("exactly one argument required: advertised listeners")
 	}
 
-	if args[0] == "" {
-		return "", fmt.Errorf("advertised listeners cannot be empty")
-	}
-
-	advertisedListeners := args[0]
-	rawListeners := strings.Split(advertisedListeners, ",")
-	processedListeners := make([]string, 0, len(rawListeners))
-
-	for _, listener := range rawListeners {
-		listener = strings.TrimSpace(listener)
-		if listener == "" {
-			continue
-		}
-
-		if strings.Contains(listener, "://") {
-			parts := strings.SplitN(listener, "://", 2)
-			if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-				return "", fmt.Errorf("malformed listener: %q", listener)
-			}
-			if strings.Contains(parts[1], "://") {
-				return "", fmt.Errorf("malformed listener: %q", listener)
-			}
-			processedListeners = append(processedListeners, parts[1])
-		} else {
-			processedListeners = append(processedListeners, listener)
-		}
-	}
-
-	if len(processedListeners) > 0 {
-		return strings.Join(processedListeners, ","), nil
-	}
-	return "", nil
+	return listenerHostRe.ReplaceAllString(args[0], "://0.0.0.0:"), nil
 }
 
 func main() {

--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -855,16 +855,9 @@ func parseLog4jLoggers(loggersStr string, defaultLoggers ...map[string]string) m
 	return result
 }
 
-// runListenersCmd derives the `listeners` value from `advertised.listeners` by
-// replacing the host of every listener entry with 0.0.0.0, so the broker binds
-// on all interfaces while still advertising its real address. The listener name
-// (protocol prefix) and port are preserved.
-//
-// This intentionally mirrors the legacy `cub` behavior exactly: a single regex
-// substitution of `://(.*?):` -> `://0.0.0.0:` over the whole input string. As a
-// result, listener names/prefixes are kept (e.g. PLAINTEXT://foo:9092 ->
-// PLAINTEXT://0.0.0.0:9092), entries without a protocol prefix pass through
-// unchanged, and surrounding whitespace/trailing separators are left intact.
+// runListenersCmd derives `listeners` from `advertised.listeners` by replacing
+// each host with 0.0.0.0 (name/prefix and port preserved). Mirrors legacy cub:
+// a single `://(.*?):` -> `://0.0.0.0:` substitution over the whole string.
 func runListenersCmd(args []string) (string, error) {
 	if len(args) != 1 {
 		return "", fmt.Errorf("exactly one argument required: advertised listeners")

--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -89,7 +89,7 @@ var (
 
 	re = regexp.MustCompile("[^_]_[^_]")
 
-	listenerHostRe = regexp.MustCompile("://(.*?):")
+	listenerHostRegex = regexp.MustCompile("://(.*?):")
 
 	ensureCmd = &cobra.Command{
 		Use:   "ensure <environment-variable>",
@@ -190,11 +190,7 @@ var (
 		Short: "extracts listeners from advertised listeners",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			listeners, err := runListenersCmd(args)
-			if err != nil {
-				return err
-			}
-			fmt.Println(listeners)
+			fmt.Println(runListenersCmd(args[0]))
 			return nil
 		},
 	}
@@ -858,12 +854,8 @@ func parseLog4jLoggers(loggersStr string, defaultLoggers ...map[string]string) m
 // runListenersCmd derives `listeners` from `advertised.listeners` by replacing
 // each host with 0.0.0.0 (name/prefix and port preserved). Mirrors legacy cub:
 // a single `://(.*?):` -> `://0.0.0.0:` substitution over the whole string.
-func runListenersCmd(args []string) (string, error) {
-	if len(args) != 1 {
-		return "", fmt.Errorf("exactly one argument required: advertised listeners")
-	}
-
-	return listenerHostRe.ReplaceAllString(args[0], "://0.0.0.0:"), nil
+func runListenersCmd(arg string) string {
+	return listenerHostRegex.ReplaceAllString(arg, "://0.0.0.0:")
 }
 
 func main() {

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -956,52 +956,78 @@ func TestRunListenersCmd(t *testing.T) {
 		expectError         bool
 	}{
 		{
+			// cub parity: keep the protocol prefix, replace host with 0.0.0.0.
 			name:                "single listener with protocol",
 			advertisedListeners: []string{"PLAINTEXT://localhost:9092"},
-			expectedOutput:      "localhost:9092",
+			expectedOutput:      "PLAINTEXT://0.0.0.0:9092",
 			expectError:         false,
 		},
 		{
 			name:                "multiple listeners with protocols",
 			advertisedListeners: []string{"PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093"},
-			expectedOutput:      "localhost:9092,localhost:9093",
+			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,SASL_PLAINTEXT://0.0.0.0:9093",
 			expectError:         false,
 		},
 		{
+			// Real-world multi-named-listener case from INC-11376.
+			name:                "named listeners",
+			advertisedListeners: []string{"BROKER://kafka1.corp:9095,SASL_SSL://kafka1.corp:9092,MTLS://kafka1.corp:9093"},
+			expectedOutput:      "BROKER://0.0.0.0:9095,SASL_SSL://0.0.0.0:9092,MTLS://0.0.0.0:9093",
+			expectError:         false,
+		},
+		{
+			// No protocol prefix => no match => passed through unchanged (cub).
 			name:                "listener without protocol",
 			advertisedListeners: []string{"localhost:9092"},
 			expectedOutput:      "localhost:9092",
 			expectError:         false,
 		},
 		{
-			name:                "mixed listeners",
+			// Only entries with a protocol prefix are rewritten.
+			name:                "mixed listeners with and without protocol",
 			advertisedListeners: []string{"PLAINTEXT://localhost:9092,localhost:9093,SASL_PLAINTEXT://localhost:9094"},
-			expectedOutput:      "localhost:9092,localhost:9093,localhost:9094",
+			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,localhost:9093,SASL_PLAINTEXT://0.0.0.0:9094",
 			expectError:         false,
 		},
 		{
+			name:                "ip host",
+			advertisedListeners: []string{"SSL://10.0.4.5:7888"},
+			expectedOutput:      "SSL://0.0.0.0:7888",
+			expectError:         false,
+		},
+		{
+			// cub does a whole-string regex sub: surrounding whitespace is preserved.
+			name:                "whitespace preserved",
+			advertisedListeners: []string{"PLAINTEXT://foo:9999, SSL://bar:9098"},
+			expectedOutput:      "PLAINTEXT://0.0.0.0:9999, SSL://0.0.0.0:9098",
+			expectError:         false,
+		},
+		{
+			// cub does not split/trim, so a trailing separator is kept as-is.
+			name:                "trailing comma preserved",
+			advertisedListeners: []string{"PLAINTEXT://localhost:9092,"},
+			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,",
+			expectError:         false,
+		},
+		{
+			// Idempotent: already-0.0.0.0 input is unchanged.
+			name:                "already zero host",
+			advertisedListeners: []string{"PLAINTEXT://0.0.0.0:9092"},
+			expectedOutput:      "PLAINTEXT://0.0.0.0:9092",
+			expectError:         false,
+		},
+		{
+			// Empty input yields empty output (cub returns ""), not an error.
 			name:                "empty advertised listeners",
 			advertisedListeners: []string{""},
 			expectedOutput:      "",
-			expectError:         true,
+			expectError:         false,
 		},
 		{
 			name:                "multiple arguments",
 			advertisedListeners: []string{"PLAINTEXT://localhost:9092", "extra-arg"},
 			expectedOutput:      "",
 			expectError:         true,
-		},
-		{
-			name:                "malformed protocol",
-			advertisedListeners: []string{"PLAINTEXT://://localhost:9092"},
-			expectedOutput:      "",
-			expectError:         true,
-		},
-		{
-			name:                "trailing comma",
-			advertisedListeners: []string{"PLAINTEXT://localhost:9092,"},
-			expectedOutput:      "localhost:9092",
-			expectError:         false,
 		},
 		{
 			name:                "no arguments",

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -950,99 +950,66 @@ func Test_setProperties(t *testing.T) {
 }
 func TestRunListenersCmd(t *testing.T) {
 	tests := []struct {
-		name                string
-		advertisedListeners []string
-		expectedOutput      string
-		expectError         bool
+		name           string
+		advertised     string
+		expectedOutput string
 	}{
 		{
-			name:                "single listener with protocol",
-			advertisedListeners: []string{"PLAINTEXT://localhost:9092"},
-			expectedOutput:      "PLAINTEXT://0.0.0.0:9092",
-			expectError:         false,
+			name:           "single listener with protocol",
+			advertised:     "PLAINTEXT://localhost:9092",
+			expectedOutput: "PLAINTEXT://0.0.0.0:9092",
 		},
 		{
-			name:                "multiple listeners with protocols",
-			advertisedListeners: []string{"PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093"},
-			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,SASL_PLAINTEXT://0.0.0.0:9093",
-			expectError:         false,
+			name:           "multiple listeners with protocols",
+			advertised:     "PLAINTEXT://localhost:9092,SASL_PLAINTEXT://localhost:9093",
+			expectedOutput: "PLAINTEXT://0.0.0.0:9092,SASL_PLAINTEXT://0.0.0.0:9093",
 		},
 		{
-			name:                "named listeners",
-			advertisedListeners: []string{"BROKER://kafka1.corp:9095,SASL_SSL://kafka1.corp:9092,MTLS://kafka1.corp:9093"},
-			expectedOutput:      "BROKER://0.0.0.0:9095,SASL_SSL://0.0.0.0:9092,MTLS://0.0.0.0:9093",
-			expectError:         false,
+			name:           "named listeners",
+			advertised:     "BROKER://kafka1.corp:9095,SASL_SSL://kafka1.corp:9092,MTLS://kafka1.corp:9093",
+			expectedOutput: "BROKER://0.0.0.0:9095,SASL_SSL://0.0.0.0:9092,MTLS://0.0.0.0:9093",
 		},
 		{
-			name:                "listener without protocol",
-			advertisedListeners: []string{"localhost:9092"},
-			expectedOutput:      "localhost:9092",
-			expectError:         false,
+			name:           "listener without protocol",
+			advertised:     "localhost:9092",
+			expectedOutput: "localhost:9092",
 		},
 		{
-			name:                "mixed listeners with and without protocol",
-			advertisedListeners: []string{"PLAINTEXT://localhost:9092,localhost:9093,SASL_PLAINTEXT://localhost:9094"},
-			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,localhost:9093,SASL_PLAINTEXT://0.0.0.0:9094",
-			expectError:         false,
+			name:           "mixed listeners with and without protocol",
+			advertised:     "PLAINTEXT://localhost:9092,localhost:9093,SASL_PLAINTEXT://localhost:9094",
+			expectedOutput: "PLAINTEXT://0.0.0.0:9092,localhost:9093,SASL_PLAINTEXT://0.0.0.0:9094",
 		},
 		{
-			name:                "ip host",
-			advertisedListeners: []string{"SSL://10.0.4.5:7888"},
-			expectedOutput:      "SSL://0.0.0.0:7888",
-			expectError:         false,
+			name:           "ip host",
+			advertised:     "SSL://10.0.4.5:7888",
+			expectedOutput: "SSL://0.0.0.0:7888",
 		},
 		{
-			name:                "whitespace preserved",
-			advertisedListeners: []string{"PLAINTEXT://foo:9999, SSL://bar:9098"},
-			expectedOutput:      "PLAINTEXT://0.0.0.0:9999, SSL://0.0.0.0:9098",
-			expectError:         false,
+			name:           "whitespace preserved",
+			advertised:     "PLAINTEXT://foo:9999, SSL://bar:9098",
+			expectedOutput: "PLAINTEXT://0.0.0.0:9999, SSL://0.0.0.0:9098",
 		},
 		{
-			name:                "trailing comma preserved",
-			advertisedListeners: []string{"PLAINTEXT://localhost:9092,"},
-			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,",
-			expectError:         false,
+			name:           "trailing comma preserved",
+			advertised:     "PLAINTEXT://localhost:9092,",
+			expectedOutput: "PLAINTEXT://0.0.0.0:9092,",
 		},
 		{
-			name:                "already zero host",
-			advertisedListeners: []string{"PLAINTEXT://0.0.0.0:9092"},
-			expectedOutput:      "PLAINTEXT://0.0.0.0:9092",
-			expectError:         false,
+			name:           "already zero host",
+			advertised:     "PLAINTEXT://0.0.0.0:9092",
+			expectedOutput: "PLAINTEXT://0.0.0.0:9092",
 		},
 		{
-			name:                "empty advertised listeners",
-			advertisedListeners: []string{""},
-			expectedOutput:      "",
-			expectError:         false,
-		},
-		{
-			name:                "multiple arguments",
-			advertisedListeners: []string{"PLAINTEXT://localhost:9092", "extra-arg"},
-			expectedOutput:      "",
-			expectError:         true,
-		},
-		{
-			name:                "no arguments",
-			advertisedListeners: []string{},
-			expectedOutput:      "",
-			expectError:         true,
+			name:           "empty advertised listeners",
+			advertised:     "",
+			expectedOutput: "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output, err := runListenersCmd(tt.advertisedListeners)
-			if tt.expectError {
-				if err == nil {
-					t.Errorf("expected error but got nil for test case: %s", tt.name)
-				}
-			} else {
-				if err != nil {
-					t.Errorf("unexpected error for test case %s: %v", tt.name, err)
-				}
-				if output != tt.expectedOutput {
-					t.Errorf("test case %s: got output %q, want %q", tt.name, output, tt.expectedOutput)
-				}
+			if output := runListenersCmd(tt.advertised); output != tt.expectedOutput {
+				t.Errorf("test case %s: got output %q, want %q", tt.name, output, tt.expectedOutput)
 			}
 		})
 	}

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -956,7 +956,6 @@ func TestRunListenersCmd(t *testing.T) {
 		expectError         bool
 	}{
 		{
-			// cub parity: keep the protocol prefix, replace host with 0.0.0.0.
 			name:                "single listener with protocol",
 			advertisedListeners: []string{"PLAINTEXT://localhost:9092"},
 			expectedOutput:      "PLAINTEXT://0.0.0.0:9092",
@@ -969,21 +968,18 @@ func TestRunListenersCmd(t *testing.T) {
 			expectError:         false,
 		},
 		{
-			// Real-world multi-named-listener case from INC-11376.
 			name:                "named listeners",
 			advertisedListeners: []string{"BROKER://kafka1.corp:9095,SASL_SSL://kafka1.corp:9092,MTLS://kafka1.corp:9093"},
 			expectedOutput:      "BROKER://0.0.0.0:9095,SASL_SSL://0.0.0.0:9092,MTLS://0.0.0.0:9093",
 			expectError:         false,
 		},
 		{
-			// No protocol prefix => no match => passed through unchanged (cub).
 			name:                "listener without protocol",
 			advertisedListeners: []string{"localhost:9092"},
 			expectedOutput:      "localhost:9092",
 			expectError:         false,
 		},
 		{
-			// Only entries with a protocol prefix are rewritten.
 			name:                "mixed listeners with and without protocol",
 			advertisedListeners: []string{"PLAINTEXT://localhost:9092,localhost:9093,SASL_PLAINTEXT://localhost:9094"},
 			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,localhost:9093,SASL_PLAINTEXT://0.0.0.0:9094",
@@ -996,28 +992,24 @@ func TestRunListenersCmd(t *testing.T) {
 			expectError:         false,
 		},
 		{
-			// cub does a whole-string regex sub: surrounding whitespace is preserved.
 			name:                "whitespace preserved",
 			advertisedListeners: []string{"PLAINTEXT://foo:9999, SSL://bar:9098"},
 			expectedOutput:      "PLAINTEXT://0.0.0.0:9999, SSL://0.0.0.0:9098",
 			expectError:         false,
 		},
 		{
-			// cub does not split/trim, so a trailing separator is kept as-is.
 			name:                "trailing comma preserved",
 			advertisedListeners: []string{"PLAINTEXT://localhost:9092,"},
 			expectedOutput:      "PLAINTEXT://0.0.0.0:9092,",
 			expectError:         false,
 		},
 		{
-			// Idempotent: already-0.0.0.0 input is unchanged.
 			name:                "already zero host",
 			advertisedListeners: []string{"PLAINTEXT://0.0.0.0:9092"},
 			expectedOutput:      "PLAINTEXT://0.0.0.0:9092",
 			expectError:         false,
 		},
 		{
-			// Empty input yields empty output (cub returns ""), not an error.
 			name:                "empty advertised listeners",
 			advertisedListeners: []string{""},
 			expectedOutput:      "",


### PR DESCRIPTION
**Why**
- `ub listeners` strips the listener name/protocol prefix and no longer substitutes the host with `0.0.0.0`, so brokers that derive `KAFKA_LISTENERS` from `KAFKA_ADVERTISED_LISTENERS` get an invalid value (e.g. `host:9092` instead of `BROKER://0.0.0.0:9092`) and fail to start (INC-11376).

**Changes**
- `runListenersCmd` now ports the exact `cub` logic: a single regex substitution `://(.*?):` → `://0.0.0.0:` over the whole input. Prefix + port preserved, host → `0.0.0.0`.
- Updated `TestRunListenersCmd` to assert cub parity (expected values verified byte-for-byte against cub's Python regex): named listeners, whitespace/trailing-comma preservation, no-protocol passthrough, idempotency.

**Notes**
- Matches legacy `cub.get_kafka_listeners` exactly (whole-string sub; no split/trim/validate). Side effect of parity: empty/malformed input no longer errors (cub never validated) and whitespace/trailing separators are preserved.
- After merge: bump `git-repo.cp-docker-utils.tag` in common-docker (8.1.x/8.2.x/8.3.x/master) to the new tag to ship it.
- INC-11376 / Zendesk #355212

**Verification**

_Unit_
```
go test ./cmd/ub/        # green (12/12)
go run ./cmd/ub listeners "BROKER://host1:9095,SASL_SSL://host1:9092,MTLS://host1:9093"
# -> BROKER://0.0.0.0:9095,SASL_SSL://0.0.0.0:9092,MTLS://0.0.0.0:9093
```

_End-to-end (image)_ — built fixed base + broker off this branch and A/B-tested vs an unmodified baseline (same pipeline, only the base image differs):
- common-docker test branch `test-ub-listeners-cub-parity` (pin `git-repo.cp-docker-utils.tag` -> `fix-ub-listeners-cub-parity`) -> fixed base `cp-base-java:dev-8.1.x-5a796613`; stock base = buggy `cp-base-java:dev-8.1.x-8b4e01d5`
- kafka-images PR #503 (point `DOCKER_UPSTREAM_REGISTRY`/`DOCKER_UPSTREAM_TAG` at the fixed base) -> fixed `cp-kafka:dev-8.1.x-6e373800`; stock base -> buggy `cp-kafka:dev-8.1.x-0d54df6a`

0) Base image (`cp-base-java`) `ub` A/B — same command, only the tag differs:
```
ub listeners "BROKER://host1:9095,SASL_SSL://host1:9092"
  cp-base-java:dev-8.1.x-5a796613 (fixed)  -> BROKER://0.0.0.0:9095,SASL_SSL://0.0.0.0:9092
  cp-base-java:dev-8.1.x-8b4e01d5 (stock)  -> host1:9095,host1:9092            (prefix stripped, host not swapped)
```

1) Direct derive (`ub` invoked explicitly), fixed broker image:
```
docker run --rm --entrypoint ub cp-kafka:dev-8.1.x-6e373800 \
  listeners "BROKER://h:9095,SASL_SSL://h:9092,MTLS://h:9093"
# -> BROKER://0.0.0.0:9095,SASL_SSL://0.0.0.0:9092,MTLS://0.0.0.0:9093
```

2) Broker boot via `configure` auto-derive (`KAFKA_LISTENERS` unset) — broker-only node + a controller on a docker network:
```
docker run --rm --name broker --network kraftnet \
  -e KAFKA_PROCESS_ROLES=broker -e KAFKA_NODE_ID=2 \
  -e KAFKA_CONTROLLER_QUORUM_VOTERS=1@controller:9093 \
  -e KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER \
  -e KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT \
  -e KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://broker:9092 \
  cp-kafka:dev-8.1.x-6e373800     # KAFKA_LISTENERS intentionally unset
```
- Fixed: `configure` runs `ub listeners` -> `listeners = PLAINTEXT://0.0.0.0:9092`, parses, reaches `Kafka Server started`.
- Buggy baseline (`...-0d54df6a`, same command): `ub` returns `broker:9092` -> broker dies at `Unable to parse broker:9092` before startup.
- A/B differs only by the base image -> confirms the fix on the real broker derivation path.