### PR TITLE
Fix ub ConvertKey single-character segment conversion (cub/dub parity)

### DIFF
--- a/cmd/ub/ub.go
+++ b/cmd/ub/ub.go
@@ -87,8 +87,6 @@ var (
 		},
 	}
 
-	re = regexp.MustCompile("[^_]_[^_]")
-
 	listenerHostRegex = regexp.MustCompile("://(.*?):")
 
 	ensureCmd = &cobra.Command{
@@ -299,14 +297,25 @@ func renderConfig(writer io.Writer, configSpec ConfigSpec) error {
 // Moreover, the whole string is converted to lower-case.
 // The behavior of sequences of four or more underscores is undefined.
 func ConvertKey(key string) string {
-	singleReplaced := re.ReplaceAllStringFunc(key, replaceUnderscores)
+	singleReplaced := dotIsolatedUnderscores(key)
 	singleTripleReplaced := strings.ReplaceAll(singleReplaced, "___", "-")
 	return strings.ToLower(strings.ReplaceAll(singleTripleReplaced, "__", "_"))
 }
 
-// replaceUnderscores replaces every underscore '_' by a dot '.'
-func replaceUnderscores(s string) string {
-	return strings.ReplaceAll(s, "_", ".")
+// dotIsolatedUnderscores replaces every '_' that has a non-'_' on both sides with '.',
+// leaving underscore runs and boundary underscores untouched. This is a RE2-safe
+// (lookaround-free) equivalent of the legacy cub/dub regex (?<=[^_])_(?=[^_]).
+func dotIsolatedUnderscores(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		if c := s[i]; c == '_' && i > 0 && i < len(s)-1 && s[i-1] != '_' && s[i+1] != '_' {
+			b.WriteByte('.')
+		} else {
+			b.WriteByte(c)
+		}
+	}
+	return b.String()
 }
 
 // ListToMap splits each and entry of the kvList argument at '=' into a key/value pair and returns a map of all the k/v pair thus obtained.

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -216,6 +216,26 @@ func Test_convertKey(t *testing.T) {
 			args:       args{key: "KEY_WITH___DASH_AND___MORE__UNDERSCORE"},
 			wantString: "key.with-dash.and-more_underscore",
 		},
+		{
+			name:       "single char segment in the middle",
+			args:       args{key: "KEY_A_FOO"},
+			wantString: "key.a.foo",
+		},
+		{
+			name:       "all single char segments",
+			args:       args{key: "A_B_C"},
+			wantString: "a.b.c",
+		},
+		{
+			name:       "chained single char segments",
+			args:       args{key: "X_Y_Z_W"},
+			wantString: "x.y.z.w",
+		},
+		{
+			name:       "single char listener name",
+			args:       args{key: "LISTENER_NAME_X_SSL_KEYSTORE_LOCATION"},
+			wantString: "listener.name.x.ssl.keystore.location",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -236,6 +236,86 @@ func Test_convertKey(t *testing.T) {
 			args:       args{key: "LISTENER_NAME_X_SSL_KEYSTORE_LOCATION"},
 			wantString: "listener.name.x.ssl.keystore.location",
 		},
+		{
+			name:       "leading single underscore",
+			args:       args{key: "_KEY"},
+			wantString: "_key",
+		},
+		{
+			name:       "trailing single underscore",
+			args:       args{key: "KEY_"},
+			wantString: "key_",
+		},
+		{
+			name:       "leading double underscore",
+			args:       args{key: "__KEY"},
+			wantString: "_key",
+		},
+		{
+			name:       "trailing double underscore",
+			args:       args{key: "KEY__"},
+			wantString: "key_",
+		},
+		{
+			name:       "leading triple underscore",
+			args:       args{key: "___KEY"},
+			wantString: "-key",
+		},
+		{
+			name:       "trailing triple underscore",
+			args:       args{key: "KEY___"},
+			wantString: "key-",
+		},
+		{
+			name:       "wrapped in single underscores with single-char segments",
+			args:       args{key: "_A_B_"},
+			wantString: "_a.b_",
+		},
+		{
+			name:       "single char wrapped in triple underscores",
+			args:       args{key: "___A___"},
+			wantString: "-a-",
+		},
+		{
+			name:       "mixed single double and triple underscores",
+			args:       args{key: "A_B__C___D"},
+			wantString: "a.b_c-d",
+		},
+		{
+			name:       "quadruple underscore",
+			args:       args{key: "A____B"},
+			wantString: "a-_b",
+		},
+		{
+			name:       "quadruple underscore in the middle",
+			args:       args{key: "KEY____FOO"},
+			wantString: "key-_foo",
+		},
+		{
+			name:       "digit segments",
+			args:       args{key: "KEY_123_BAR"},
+			wantString: "key.123.bar",
+		},
+		{
+			name:       "only double underscore",
+			args:       args{key: "__"},
+			wantString: "_",
+		},
+		{
+			name:       "only triple underscore",
+			args:       args{key: "___"},
+			wantString: "-",
+		},
+		{
+			name:       "consecutive single-char segments with double underscores",
+			args:       args{key: "A__B__C"},
+			wantString: "a_b_c",
+		},
+		{
+			name:       "leading and trailing double underscores around single-char segments",
+			args:       args{key: "__A_B__"},
+			wantString: "_a.b_",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/ub/ub_test.go
+++ b/cmd/ub/ub_test.go
@@ -237,49 +237,24 @@ func Test_convertKey(t *testing.T) {
 			wantString: "listener.name.x.ssl.keystore.location",
 		},
 		{
-			name:       "leading single underscore",
+			name:       "leading single underscore kept",
 			args:       args{key: "_KEY"},
 			wantString: "_key",
 		},
 		{
-			name:       "trailing single underscore",
+			name:       "trailing single underscore kept",
 			args:       args{key: "KEY_"},
 			wantString: "key_",
 		},
 		{
-			name:       "leading double underscore",
-			args:       args{key: "__KEY"},
-			wantString: "_key",
-		},
-		{
-			name:       "trailing double underscore",
-			args:       args{key: "KEY__"},
-			wantString: "key_",
-		},
-		{
-			name:       "leading triple underscore",
+			name:       "leading triple underscore run",
 			args:       args{key: "___KEY"},
 			wantString: "-key",
 		},
 		{
-			name:       "trailing triple underscore",
-			args:       args{key: "KEY___"},
-			wantString: "key-",
-		},
-		{
-			name:       "wrapped in single underscores with single-char segments",
-			args:       args{key: "_A_B_"},
-			wantString: "_a.b_",
-		},
-		{
-			name:       "single char wrapped in triple underscores",
+			name:       "single char adjacent to underscore runs",
 			args:       args{key: "___A___"},
 			wantString: "-a-",
-		},
-		{
-			name:       "mixed single double and triple underscores",
-			args:       args{key: "A_B__C___D"},
-			wantString: "a.b_c-d",
 		},
 		{
 			name:       "quadruple underscore",
@@ -287,34 +262,9 @@ func Test_convertKey(t *testing.T) {
 			wantString: "a-_b",
 		},
 		{
-			name:       "quadruple underscore in the middle",
-			args:       args{key: "KEY____FOO"},
-			wantString: "key-_foo",
-		},
-		{
 			name:       "digit segments",
 			args:       args{key: "KEY_123_BAR"},
 			wantString: "key.123.bar",
-		},
-		{
-			name:       "only double underscore",
-			args:       args{key: "__"},
-			wantString: "_",
-		},
-		{
-			name:       "only triple underscore",
-			args:       args{key: "___"},
-			wantString: "-",
-		},
-		{
-			name:       "consecutive single-char segments with double underscores",
-			args:       args{key: "A__B__C"},
-			wantString: "a_b_c",
-		},
-		{
-			name:       "leading and trailing double underscores around single-char segments",
-			args:       args{key: "__A_B__"},
-			wantString: "_a.b_",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Problem**
`ub` converts env-var names to property names (`envToProps`→`ConvertKey`) on every cp-kafka/cp-server/connect boot. A **single-character segment between single underscores** is mis-converted: the `_` after it stays `_` instead of becoming `.`. Multi-char segments are fine, so it slipped through. Regression vs legacy cub/dub.

**Repro — same template, same env, old image (dub) vs current image (ub)** (captured)
```
# current 8.1.x (ub):  docker run --entrypoint ub <cp-kafka 8.1.x> \
#   -e KAFKA_LISTENER_NAME_X_SSL_KEYSTORE_LOCATION=/sec/x.jks \
#   -e KAFKA_LISTENER_NAME_S_SSL_KEYSTORE_TYPE=PKCS12 \
#   -e KAFKA_LISTENER_NAME_EXTERNAL_SSL_KEYSTORE_LOCATION=/sec/ext.jks \
#   -e KAFKA_NUM_NETWORK_THREADS=3 \
#   render-template /etc/confluent/docker/kafka.properties.template
listener.name.external.ssl.keystore.location=/sec/ext.jks   # multi-char OK
listener.name.s_ssl.keystore.type=PKCS12                    # single-char "S" -> WRONG (s_ssl)
listener.name.x_ssl.keystore.location=/sec/x.jks            # single-char "X" -> WRONG (x_ssl)
num.network.threads=3

# 8.0.x (dub):  docker run --entrypoint dub confluentinc/cp-kafka:8.0.5 \
#   <same -e flags> \
#   template /etc/confluent/docker/kafka.properties.template /dev/stdout
listener.name.external.ssl.keystore.location=/sec/ext.jks   # multi-char OK
listener.name.s.ssl.keystore.type=PKCS12                    # single-char "S" -> CORRECT
listener.name.x.ssl.keystore.location=/sec/x.jks            # single-char "X" -> CORRECT
num.network.threads=3
```

**The problem case**: a listener named with a single char (`KAFKA_LISTENER_NAME_X_SSL_*`) -> ub writes `listener.name.x_ssl.*`, an unknown key Kafka silently ignores -> that listener boots without its SSL config. Multi-char names (`EXTERNAL`, `INTERNAL`) are unaffected.

**Reason**: dub used a zero-width lookaround `(?<=[^_])_(?=[^_])`. Go RE2 has no lookaround, so ub used the consuming `[^_]_[^_]`; non-overlapping matches **eat** the 1-char segment, orphaning the next `_` so it never converts.

**Fix**: replace the regex step with `dotIsolatedUnderscores` — a lookaround-free byte-scan that dots a `_` only when both neighbours are non-`_`. Drops the now-unused `re` var + `replaceUnderscores` helper (`regexp` import kept — still used by `listenerHostRegex`). Steps 2&3 (`___`->`-`, `__`->`_`) unchanged.

**Validation**: byte-for-byte vs legacy cub/dub across 85 names (0 divergences). `Test_convertKey` = 16 cases:
- **4 regression tests** (`A_B_C`, `X_Y_Z_W`, `KEY_A_FOO`, `LISTENER_NAME_X_SSL_*`) — fail on old logic, pass on new.
- **6 edge cases** (leading `_`, trailing `_`, leading run, char adjacent to runs, 4+ run, digits) — one per distinct behavior; expected values from the dub reference, verified identical between 8.0.x `dub` and 8.1.x `ub`.
- 6 pre-existing cases (single/double/triple/mixed) retained.